### PR TITLE
fix(build): setup travis push

### DIFF
--- a/build/push.sh
+++ b/build/push.sh
@@ -48,6 +48,14 @@ fi
 
 # The below steps are required for pushing arch specific images.
 # This steps will be removed eventually in favour of buildx-push
+IMAGEID=$( sudo docker images -q ${DIMAGE}:ci )
+echo "${DIMAGE}:ci -> $IMAGEID"
+if [ -z ${IMAGEID} ];
+then
+  echo "Error: unable to get IMAGEID for ${DIMAGE}:ci";
+  exit 1
+fi
+
 
 # Generate a unique tag based on the commit and tag
 BUILD_ID=$(git describe --tags --always)

--- a/build/push.sh
+++ b/build/push.sh
@@ -48,9 +48,9 @@ fi
 
 # The below steps are required for pushing arch specific images.
 # This steps will be removed eventually in favour of buildx-push
-IMAGEID=$( sudo docker images -q ${DIMAGE}:ci )
+IMAGEID=$( sudo docker images -q "${DIMAGE}:ci" )
 echo "${DIMAGE}:ci -> $IMAGEID"
-if [ -z ${IMAGEID} ];
+if [ -z "${IMAGEID}" ];
 then
   echo "Error: unable to get IMAGEID for ${DIMAGE}:ci";
   exit 1


### PR DESCRIPTION
A step to extract the IMAGEID of the ci image was missed
causing travis to fail pushing the images.

Added the step to extract IMAGEID.

Signed-off-by: kmova <kiran.mova@mayadata.io>


