### PR TITLE
refact(build): run only amd64 and arm64 builds

### DIFF
--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -25,7 +25,7 @@ endif
 
 # default list of platforms for which multiarch image is built
 ifeq (${PLATFORMS}, )
-	export PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le"
+	export PLATFORMS="linux/amd64,linux/arm64"
 endif
 
 # if IMG_RESULT is unspecified, by default the image will be pushed to registry

--- a/build/exporter/exporter.Dockerfile
+++ b/build/exporter/exporter.Dockerfile
@@ -29,7 +29,7 @@ ENV GO111MODULE=on \
   DEBIAN_FRONTEND=noninteractive \
   PATH="/root/go/bin:${PATH}"
 
-WORKDIR /go/src/github.com/openebs/openebs-exporter
+WORKDIR /go/src/github.com/openebs/m-exporter
 
 RUN apt-get update && apt-get install -y make git
 
@@ -54,7 +54,7 @@ LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 # copy the latest binary
-COPY --from=build /go/src/github.com/openebs/openebs-exporter/bin/exporter/exporter /usr/local/bin/maya-exporter
+COPY --from=build /go/src/github.com/openebs/m-exporter/bin/exporter/exporter /usr/local/bin/maya-exporter
 
 CMD maya-exporter
 EXPOSE 9500


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does?**:
Enabling more than two arch in the multi-arch builds
is resulting in increased build times as well as
intermittent failures in running the builds.

Limiting to two archs - amd64 and arm64 for now.


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
